### PR TITLE
Adding customFilePath parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ PT-E800W, PT-D800W, PT-E850TKW
 PT-P900W, PT-P950NW
 ```
 
-__Tested models:__ `QL-720NW`, `QL-820NWB`
+__Tested models:__ `QL-720NW`, `QL-820NWB`, `TD-2120N`
 
 (if you have tried this with other models, please update this list and send a pull request)
 

--- a/src/android/BasePrint.java
+++ b/src/android/BasePrint.java
@@ -483,7 +483,7 @@ public abstract class BasePrint {
                 if (manualCustomPaperSettingsEnabled) {
                     result = setManualCustomPaper(mPrinterInfo.printerModel);
                 } else {
-                    mPrinterInfo.customPaper = Common.CUSTOM_PAPER_FOLDER + customSetting;
+                    mPrinterInfo.customPaper = customSetting;
                     result = setManualCustomPaper(null);
                 }
                 break;

--- a/src/android/BrotherPrinter.java
+++ b/src/android/BrotherPrinter.java
@@ -617,7 +617,7 @@ public class BrotherPrinter extends CordovaPlugin {
             out.close();
             out = null;
         } catch (Exception e) {
-            Log.e("Brother/SDKEvent", "Exception in copyFile() " + e.toString());
+            Log.e("Brother/SDKEvent", "Exception in copyBinFile() " + e.toString());
         }
 
     }

--- a/src/android/BrotherPrinter.java
+++ b/src/android/BrotherPrinter.java
@@ -1,10 +1,9 @@
 package com.threescreens.cordova.plugin.brotherprinter;
 
+import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -33,12 +32,11 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.preference.PreferenceManager;
-import android.support.v4.app.ActivityCompat;
-import android.telecom.Call;
 import android.util.Base64;
 import android.util.Log;
 
@@ -64,6 +62,7 @@ public class BrotherPrinter extends CordovaPlugin {
             PrinterInfo.Model.QL_720NW,
             PrinterInfo.Model.QL_820NWB,
             PrinterInfo.Model.QL_1110NWB,
+            PrinterInfo.Model.TD_2120N
     };
 
     private MsgHandle mHandle;
@@ -152,6 +151,7 @@ public class BrotherPrinter extends CordovaPlugin {
         public String orientation;
         public String numberOfCopies;
         public String includeBatteryStatus;
+        public String customPaperFilePath;
 
         public DiscoveredPrinter(BluetoothDevice device) {
             port = PrinterInfo.Port.BLUETOOTH;
@@ -231,6 +231,10 @@ public class BrotherPrinter extends CordovaPlugin {
                 numberOfCopies = object.getString("numberOfCopies");
             }
 
+            if(object.has("customPaperFilePath")) {
+                customPaperFilePath = object.getString("customPaperFilePath");
+            }
+
             if (object.has(INCLUDE_BATTERY_STATUS)) {
                 includeBatteryStatus = object.getString(INCLUDE_BATTERY_STATUS);
             } else {
@@ -250,6 +254,9 @@ public class BrotherPrinter extends CordovaPlugin {
             result.put("nodeName", nodeName);
             result.put("location", location);
             result.put("paperLabelName", paperLabelName);
+            result.put("orientation", orientation);
+            result.put("numberOfCopies", numberOfCopies);
+            result.put("customPaperFilePath", customPaperFilePath);
             return result;
         }
     }
@@ -386,6 +393,13 @@ public class BrotherPrinter extends CordovaPlugin {
             editor.putString("paperSize", printer.paperLabelName != null ? printer.paperLabelName : LabelInfo.QL700.W62.toString());
             editor.putString("orientation", printer.orientation != null ? printer.orientation : PrinterInfo.Orientation.LANDSCAPE.toString());
             editor.putString("numberOfCopies", printer.numberOfCopies);
+
+            if(!printer.customPaperFilePath.isEmpty()) {
+                String targetBinFolder = cordova.getActivity()
+                        .getExternalFilesDir("customPaperFileSet/").toString();
+                copyBinFile("www/" + printer.customPaperFilePath, targetBinFolder);
+                editor.putString("customSetting", targetBinFolder + new File(printer.customPaperFilePath).getName());
+            }
 
             editor.putString(INCLUDE_BATTERY_STATUS, printer.includeBatteryStatus);
 
@@ -554,7 +568,6 @@ public class BrotherPrinter extends CordovaPlugin {
                 //label info must be set after setPrinterInfo, it's not in the docs
                 myPrinter.setLabelInfo(myLabelInfo);
 
-
                 try {
                     File outputDir = context.getCacheDir();
                     File outputFile = new File(outputDir.getPath() + "configure.prn");
@@ -579,6 +592,34 @@ public class BrotherPrinter extends CordovaPlugin {
                 }
             }
         });
+    }
+
+    private void copyBinFile(String filename, String targetPath) {
+        AssetManager assetManager = cordova.getActivity().getAssets();
+        InputStream in = null;
+        OutputStream out = null;
+        String newFileName = null;
+        try {
+            in = assetManager.open(filename);
+
+            newFileName = targetPath + filename.substring(filename.lastIndexOf("/")+1);
+
+            out = new FileOutputStream(newFileName);
+
+            byte[] buffer = new byte[1024];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+            in.close();
+            in = null;
+            out.flush();
+            out.close();
+            out = null;
+        } catch (Exception e) {
+            Log.e("Brother/SDKEvent", "Exception in copyFile() " + e.toString());
+        }
+
     }
 
 }

--- a/src/android/Common.java
+++ b/src/android/Common.java
@@ -86,9 +86,6 @@ public class Common {
     // Activity_Settings
     public static final int FOLDER_SELECT = 10016;
 
-    public static final String CUSTOM_PAPER_FOLDER = Environment
-            .getExternalStorageDirectory().toString() + "/customPaperFileSet/";
-
     public static int mUsbRequest;
 
     public enum BatteryStatus {

--- a/src/ios/BrotherPrinter.h
+++ b/src/ios/BrotherPrinter.h
@@ -5,9 +5,10 @@
 #import <BRLMPrinterKit/BRPtouchPrinterKit.h>
 #import "BRBluetoothPrintOperation.h"
 #import "BRWLANPrintOperation.h"
-#define kPaperLabelName		@"paperLabelName"
+#define kPaperLabelName        @"paperLabelName"
 #define kPrintNumberOfPaperKey		@"numberOfCopies"
 #define kPrintOrientationKey		@"orientation"
+#define kCustomPaperFilePath        @"customPaperFilePath"
 
 static NSString *const IS_FINISHED_FOR_WLAN = @"isFinishedForWLAN";
 


### PR DESCRIPTION
This commit proposes the addition of a "customPaperFilePath" parameter taking a path to a .bin file for TD and RJ type printers (Only tested on a TD-2120N), for example (Ionic):

`
thePrinter.customPaperFilePath = 'assets/printer/bin/51x26.bin';
`

The addition concerns the Android and iOS platforms.

I don't know if the code is optimal, maybe a review is needed.